### PR TITLE
Skip undefined values during init

### DIFF
--- a/projects/cloudflare-stream/src/lib/cloudflare-stream.component.ts
+++ b/projects/cloudflare-stream/src/lib/cloudflare-stream.component.ts
@@ -274,7 +274,12 @@ export class CloudflareStreamComponent
     // properties onto the element
     this.syncProperties(
       // pluck current propertyProps off of the component instance to sync them to streamEl
-      propertyProps.reduce((acc, prop) => ({ ...acc, [prop]: this[prop] }), {})
+      propertyProps.reduce(
+        (acc, prop) =>
+          // skip values that are undefined
+          this[prop] === undefined ? acc : { ...acc, [prop]: this[prop] },
+        {}
+      )
     );
     this.loadStreamScript();
   }

--- a/src/stories/0-Welcome.stories.ts
+++ b/src/stories/0-Welcome.stories.ts
@@ -3,11 +3,16 @@ import { IStory } from '@storybook/angular';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { withKnobs, text, boolean, number } from '@storybook/addon-knobs';
 import { actions } from './actions';
+import {
+  DocumentWrapper,
+  getDocument,
+} from '../../projects/cloudflare-stream/src/lib/document-wrapper';
 
 const defaultVideoId = '644822f93dcddab3e9441587d184ca2f';
 
 const moduleMetadata = {
   schemas: [NO_ERRORS_SCHEMA],
+  providers: [{ provide: DocumentWrapper, useFactory: getDocument }],
 };
 
 export default {
@@ -55,6 +60,7 @@ export const autoplay = (): IStory => ({
     src: defaultVideoId,
     controls: true,
     autoplay: boolean('autoplay', true),
+    muted: boolean('muted', true),
     ...actions,
   },
   moduleMetadata,


### PR DESCRIPTION
These properties should simply be omitted during initialization. Setting them can cause issues, especially when the type should never be undefined.

The added stories providers were necessary to get storybook up and running again, and the autoplay story should also include `muted` by default so we can easily test on Safari.